### PR TITLE
feat: optimize popup UI for single window users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tab-organizer",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Chrome extension for organizing tabs by URL and domain",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Tab Organizer",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Sort and organize tabs by URL and domain",
   "permissions": [
     "tabs",

--- a/src/popup.js
+++ b/src/popup.js
@@ -7,6 +7,9 @@ document.addEventListener('DOMContentLoaded', function () {
   
   // Setup event listeners for both modes
   setupEventListeners();
+  
+  // Update UI based on number of windows
+  updateUIForWindowCount();
 });
 
 // Tab switching functionality
@@ -173,5 +176,34 @@ function moveAllToSingleWindow(respectGroups = true) {
       activeTabId: activeTab.id,
       respectGroups
     });
+  });
+}
+
+// Update UI based on number of windows
+function updateUIForWindowCount() {
+  chrome.windows.getAll({ populate: false }, function (windows) {
+    const windowCount = windows.length;
+    const isSingleWindow = windowCount === 1;
+    
+    if (isSingleWindow) {
+      // Elements that should be hidden when only one window exists
+      const multiWindowElements = [
+        'sortAllWindows-groups',
+        'sortAllWindows-individual',
+        'moveAllToSingleWindow-groups',
+        'moveAllToSingleWindow-individual',
+        'removeDuplicatesAllWindows-groups',
+        'removeDuplicatesAllWindows-individual',
+        'removeDuplicatesGlobally-groups',
+        'removeDuplicatesGlobally-individual'
+      ];
+      
+      multiWindowElements.forEach(elementId => {
+        const element = document.getElementById(elementId);
+        if (element) {
+          element.style.display = 'none';
+        }
+      });
+    }
   });
 }


### PR DESCRIPTION
## Summary
- Hide multi-window buttons when only one browser window is open
- Improves UX by showing only relevant functionality to single-window users
- Version bumped to 2.1.0

## Changes
- Added `updateUIForWindowCount()` function to detect window count
- Hide buttons: Sort All Tabs, Move All to Single Window, All Windows duplicates removal
- Keep relevant buttons: Sort Current Window, Extract Domain/All Domains, Window duplicates removal

## Test plan
- [ ] Test with single window - verify multi-window buttons are hidden
- [ ] Test with multiple windows - verify all buttons are visible
- [ ] Test functionality of remaining buttons in single window mode

🤖 Generated with [Claude Code](https://claude.ai/code)